### PR TITLE
fixed document issue

### DIFF
--- a/docs/zh/howto-setup-env-chrome.md
+++ b/docs/zh/howto-setup-env-chrome.md
@@ -37,7 +37,7 @@ mkdir $WS/chromium && cd $WS/chromium
 fetch --nohooks android
 cd src
 git checkout 109.0.5414.87
-build/install-build-deps.sh --android
+build/install-build-deps-android.sh
 gclient sync
 ```
 


### PR DESCRIPTION
For 109, should use "build/install-build-deps-android.sh". In latest version, this file has been removed and we should use "build/install-build-deps.sh --android".

The problem is this document is working on 109 but I used the commaned required for latest version(on latest main branch).